### PR TITLE
cicd(update workflow): reload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,52 @@
-# ... (rest of the workflow file)
+name: Deploy to GitHub Pages
 
-# This step is often used to upload the built site
-- name: Upload pages artifact
-  uses: actions/upload-pages-artifact@v3
-  with:
-    # THIS is the crucial line you must ensure is set to 'src'
-    path: 'src' 
+on:
+  push:
+    # Set this to the branch you want to trigger the deployment from (e.g., main or master)
+    branches: ["main"] 
+  
+  # Allows you to run the workflow manually from the Actions tab
+  workflow_dispatch:
 
-# ... (rest of the workflow file)
+# Grant GITHUB_TOKEN the permissions required for deployment
+permissions:
+  contents: read
+  pages: write       # Required to deploy to Pages
+  id-token: write    # Required for the deploy-pages action
+
+jobs:
+  # The 'build' job checks out the code and uploads the artifact
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      # Optional: If your project needs to be built (e.g., React, Vue, Svelte), add your build steps here:
+      # - name: Setup Node.js
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     node-version: '20' 
+      # - name: Install dependencies
+      #   run: npm install
+      # - name: Build static site (assuming it outputs to 'src' or you copy files to 'src')
+      #   run: npm run build 
+      
+      # This step packages the files in the 'src' folder and uploads them as an artifact
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # THIS IS THE KEY PART: It points the deployment artifact to your 'src' folder
+          path: 'src' 
+
+  # The 'deploy' job takes the uploaded artifact and publishes it to GitHub Pages
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build # Ensures this job only runs after the 'build' job completes successfully
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying to GitHub Pages, making the deployment process more robust and easier to manage. The workflow is now split into distinct build and deploy jobs, includes better permissions handling, and supports manual triggers.

**Workflow improvements:**

* Added explicit workflow triggers for pushes to the `main` branch and manual dispatch via the Actions tab, making deployments more predictable and controllable.
* Introduced a dedicated `build` job that checks out the code and uploads the static site files from the `src` folder as an artifact, clarifying the build and artifact upload steps.
* Added a separate `deploy` job that publishes the uploaded artifact to GitHub Pages, ensuring deployment only happens after a successful build.

**Permissions and configuration:**

* Explicitly set permissions for `contents`, `pages`, and `id-token` to the required levels for deployment, improving security and reliability.

**Extensibility:**

* Included commented-out steps for Node.js setup and static site building, making it easier to adapt the workflow for projects that require a build process.