### PR TITLE
ci(deploy): change environment to access secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
+    environment: github-pages
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a small configuration update to the GitHub Actions deployment workflow. The change sets the deployment environment to `github-pages` for the `build` job. This helps ensure that deployments are correctly tracked and managed within the specified environment.